### PR TITLE
feat: Simplify tags in exported metrics

### DIFF
--- a/app/metrics/__init__.py
+++ b/app/metrics/__init__.py
@@ -35,8 +35,11 @@ GAUGES = [
     "event_cache_size",
 ]
 
-INFOS = [
+KEYS = [
     "homeserver",
+]
+
+INFOS = KEYS + [
     "server_context",
     "python_version",
     "database_engine",
@@ -71,6 +74,9 @@ class Prometheus:
             {"version": app.config["VERSION"], "build": app.config["BUILD"]}
         )
         self.metrics = {
-            metric: Gauge(app.config["METRICS_PREFIX"] + metric, metric, INFOS)
+            metric: Gauge(app.config["METRICS_PREFIX"] + metric, metric, KEYS)
             for metric in GAUGES
         }
+        self.metrics["info"] = Gauge(
+            app.config["METRICS_PREFIX"] + "info", "info", INFOS
+        )


### PR DESCRIPTION
As per this [comment](https://github.com/famedly/helm-charts/issues/187#issuecomment-2921297281), and based on https://github.com/loelkes/synapse-usage-exporter/pull/1 which appears to be stalled due to the original maintainer.

Difference is the following:

**Original Version**
- All metrics had **6 labels**: `homeserver`, `server_context`, `python_version`, `database_engine`, `database_server_version`, `log_level`
- Example: `synapse_usage_total_users{homeserver="...", server_context="...", python_version="...", database_engine="...", database_server_version="...", log_level="..."}`

**New Version**
- Regular metrics have **1 label**: `homeserver` only
- Separate `synapse_usage_info` metric with **6 labels** containing metadata
- Example: 
  - `synapse_usage_total_users{homeserver="synapse.test.jan.scw.famedly.net"}`
  - `synapse_usage_info{homeserver="synapse.test.jan.scw.famedly.net", server_context="None", python_version="3.12.9", database_engine="psycopg2", database_server_version="15.12", log_level="INFO"}`